### PR TITLE
replace `toSearch` with `toQueryClause`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,14 @@ filter to their input; trimming their results on the fly.
 
 ## `methods`
 
-### `constructor(search)`
+### `constructor(queryClause)`
 
-- `search` - An [elasticsearch query (DSL) clause](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html)
+- `queryClause` - An [elasticsearch query (DSL) clause](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html)
 
 ```js
 var FilterBuilder = require('elasticsearch-filter-append')
 
-var search = {
-  from: 99,
+var queryClause = {
   filter: {
     term: {
       name: 'Atlanta, GA'
@@ -27,7 +26,7 @@ var search = {
   }
 }
 
-var builder = new FilterBuilder(search)
+var builder = new FilterBuilder(queryClause)
 ```
 
 ### `append(filter1, filter2, filter3....filterN|Array)`
@@ -37,8 +36,7 @@ var builder = new FilterBuilder(search)
 ```js
 var FilterBuilder = require('elasticsearch-filter-append')
 
-var search = {
-  from: 99,
+var queryClause = {
   filter: {
     term: {
       name: 'Atlanta, GA'
@@ -58,7 +56,7 @@ var filter2 = {
   }
 }
 
-var builder = new FilterBuilder(search)
+var builder = new FilterBuilder(queryClause)
 
 builder.append(filter1, filter2)
 ```
@@ -68,8 +66,7 @@ builder.append(filter1, filter2)
 ```js
 var FilterBuilder = require('elasticsearch-filter-append')
 
-var search = {
-  from: 99,
+var queryClause = {
   filter: {
     term: {
       name: 'Atlanta, GA'
@@ -91,7 +88,7 @@ var filter2 = {
 
 var filters = [filter1, filter2]
 
-var builder = new FilterBuilder(search)
+var builder = new FilterBuilder(queryClause)
 
 builder.append(filters)
 ```
@@ -104,16 +101,41 @@ provided must evaluate to true. You can apply as many groups of conditions as yo
 You could call `append` as follows:
 
 ```
-var secureSearch = builder.append(filter1, filter2).append(filter3).toSearch()
+var secureQueryClause = builder.append(filter1, filter2).append(filter3).toQueryClause()
 ```
 
 Yes, did I mention that `append` also supports chaining? :wink:
 
-### `toSearch()`
+### `toQueryClause()`
 
-`toSearch` is very straightforward. It unwraps the accumulated filter. It should be called subsequent to calls to
-`append`. `append` will take the latest state of the search/filter into account while chaining. For example,
+`toQueryClause` is very straightforward. It unwraps the accumulated filter. It should be called subsequent to calls to
+`append`. `append` will take the latest state of the query clause into account while chaining. For example,
 you could go from a query, to a filtered query with a `should` filter, to a filtered query with a `must` filter.
+Once you have a query clause, you can forward the final payload off to elasticsearch:
+
+```
+var elasticsearch = require('elasticsearch')
+var FilterBuilder = require('elasticsearch-filter-append')
+
+var queryClause = {
+  filter: {
+    term: {
+      name: 'Atlanta, GA'
+    }
+  }
+}
+
+var filter = {
+  term: {
+    name: 'Wimberly'
+  }
+}
+
+var builder = new FilterBuilder(queryClause)
+
+builder.append(filter)
+
+```
 
 ## `bool must filter - array`
 
@@ -122,7 +144,7 @@ you could go from a query, to a filtered query with a `should` filter, to a filt
 ```js
 var FilterBuilder = require('elasticsearch-filter-append')
 
-var search = {
+var queryClause = {
   filter: {
     bool: {
       must: [
@@ -153,14 +175,14 @@ var filter = {
   }
 }
 
-var builder = new FilterBuilder(search)
+var builder = new FilterBuilder(queryClause)
 
 builder.append(filter)
 ```
 
 ### `Δδ`
 
-`builder.toSearch()`
+`builder.toQueryClause()`
 
 ```js
 {
@@ -207,7 +229,7 @@ builder.append(filter)
 ```js
 var FilterBuilder = require('elasticsearch-filter-append')
 
-var search = {
+var queryClause = {
   filter: {
     bool: {
       must: {
@@ -225,14 +247,14 @@ var filter = {
   }
 }
 
-var builder = new FilterBuilder(search)
+var builder = new FilterBuilder(queryClause)
 
 builder.append(filter)
 ```
 
 ### `Δδ`
 
-`builder.toSearch()`
+`builder.toQueryClause()`
 
 ```js
 {
@@ -268,7 +290,7 @@ builder.append(filter)
 ```js
 var FilterBuilder = require('elasticsearch-filter-append')
 
-var search = {
+var queryClause = {
   filter: {
     bool: {
       should: [
@@ -301,14 +323,14 @@ var filter = {
   }
 }
 
-var builder = new FilterBuilder(search)
+var builder = new FilterBuilder(queryClause)
 
 builder.append(filter)
 ```
 
 ### `Δδ`
 
-`builder.toSearch()`
+`builder.toQueryClause()`
 
 ```js
 {
@@ -363,8 +385,7 @@ builder.append(filter)
 ```js
 var FilterBuilder = require('elasticsearch-filter-append')
 
-var search = {
-  fields: ['one'],
+var queryClause = {
   query: {
     filtered: {
       query: {
@@ -410,18 +431,17 @@ var filter = {
   }
 }
 
-var builder = new FilterBuilder(search)
+var builder = new FilterBuilder(queryClause)
 
 builder.append(filter)
 ```
 
 ### `Δδ`
 
-`builder.toSearch()`
+`builder.toQueryClause()`
 
 ```js
 {
-  fields: ['one'],
   query: {
     filtered: {
       query: {
@@ -480,8 +500,7 @@ builder.append(filter)
 ```js
 var FilterBuilder = require('elasticsearch-filter-append')
 
-var search = {
-  fields: ['one'],
+var queryClause = {
   query: {
     filtered: {
       query: {
@@ -514,17 +533,16 @@ var filter = {
   }
 }
 
-var builder = new FilterBuilder(search)
+var builder = new FilterBuilder(queryClause)
 
 builder.append(filter)
 ```
 ### `Δδ`
 
-`builder.toSearch()`
+`builder.toQueryClause()`
 
 ```js
 {
-  fields: ['one'],
   query: {
     filtered: {
       query: {
@@ -572,8 +590,7 @@ builder.append(filter)
 ```js
 var FilterBuilder = require('elasticsearch-filter-append')
 
-var search = {
-  fields: ['one'],
+var queryClause = {
   query: {
     filtered: {
       query: {
@@ -621,18 +638,17 @@ var filter = {
   }
 }
 
-var builder = new FilterBuilder(search)
+var builder = new FilterBuilder(queryClause)
 
 builder.append(filter)
 ```
 
 ### `Δδ`
 
-`builder.toSearch()`
+`builder.toQueryClause()`
 
 ```js
 {
-  fields: ['one'],
   query: {
     filtered: {
       query: {
@@ -699,8 +715,7 @@ builder.append(filter)
 ```js
 var FilterBuilder = require('elasticsearch-filter-append')
 
-var search = {
-  fields: ['one'],
+var queryClause = {
   query: {
     filtered: {
       query: {
@@ -729,18 +744,17 @@ var filter = {
   }
 }
 
-var builder = new FilterBuilder(search)
+var builder = new FilterBuilder(queryClause)
 
 builder.append(filter)
 ```
 
 ### `Δδ`
 
-`builder.toSearch()`
+`builder.toQueryClause()`
 
 ```js
 {
-  fields: ['one'],
   query: {
     filtered: {
       query: {
@@ -788,7 +802,7 @@ builder.append(filter)
 ```js
 var FilterBuilder = require('elasticsearch-filter-append')
 
-var search = {
+var queryClause = {
   query: {
     query_string: {
       query: "*I spy an @kyspy \\? \\* &*",
@@ -804,14 +818,14 @@ var filter = {
   }
 }
 
-var builder = new FilterBuilder(search)
+var builder = new FilterBuilder(queryClause)
 
 builder.append(filter)
 ```
 
 ### `Δδ`
 
-`builder.toSearch()`
+`builder.toQueryClause()`
 
 ```js
 {
@@ -847,7 +861,7 @@ builder.append(filter)
 ```js
 var FilterBuilder = require('elasticsearch-filter-append')
 
-var search = {
+var queryClause = {
   filter: {
     term: {
       name: 'Antwan Atkins'
@@ -861,14 +875,14 @@ var filter = {
   }
 }
 
-var builder = new FilterBuilder(search)
+var builder = new FilterBuilder(queryClause)
 
 builder.append(filter)
 ```
 
 ### `Δδ`
 
-`builder.toSearch()`
+`builder.toQueryClause()`
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ var filter = {
   }
 }
 
-var builder = new FilterBuilder(queryClause)
+var builder = new FilterBuilder(queryClause).toQueryClause()
 
 var secureQueryClause = builder.append(filter)
 

--- a/README.md
+++ b/README.md
@@ -133,8 +133,13 @@ var filter = {
 
 var builder = new FilterBuilder(queryClause)
 
-builder.append(filter)
+var secureQueryClause = builder.append(filter)
 
+elasticsearch.search({
+  body: secureQueryClause,
+  type: 'my type',
+  index: 'my ixndex'
+})
 ```
 
 ## `bool must filter - array`

--- a/index.js
+++ b/index.js
@@ -3,41 +3,41 @@ var toArray = require('lodash.toarray')
 var clone = require('lodash.clone')
 var isArray = require('lodash.isarray')
 
-function validateSearch (search) {
-  if (!search) {
-    throw new TypeError('search is required')
+function validateQueryClause (queryClause) {
+  if (!queryClause) {
+    throw new TypeError('queryClause is required')
   }
 
-  if (!search.filter && !search.query) {
-    throw new Error('invalid search. one of search.filter or search.query is required.')
+  if (!queryClause.filter && !queryClause.query) {
+    throw new Error('invalid queryClause. one of queryClause.filter or queryClause.query is required.')
   }
 
-  if (search.query && search.query.filtered && (!search.query.filtered.query || !search.query.filtered.filter)) {
+  if (queryClause.query && queryClause.query.filtered && (!queryClause.query.filtered.query || !queryClause.query.filtered.filter)) {
     throw new Error('filtered queries require a filter and a query')
   }
 }
 
-function FilterBuilder (search) {
-  validateSearch(search)
+function FilterBuilder (queryClause) {
+  validateQueryClause(queryClause)
 
-  this._search = clone(search)
+  this._queryClause = clone(queryClause)
 }
 
 FilterBuilder.prototype.append = function () {
-  var strategy = builderStrategy(this._search)
+  var strategy = builderStrategy(this._queryClause)
   var filters = isArray(arguments[0]) && arguments.length === 1 ? arguments[0] : toArray(arguments)
 
   if (!filters.length) {
     throw new Error('a minimum of one filter is required')
   }
 
-  strategy(this._search, filters)
+  strategy(this._queryClause, filters)
 
   return this
 }
 
-FilterBuilder.prototype.toSearch = function () {
-  return this._search
+FilterBuilder.prototype.toQueryClause = function () {
+  return this._queryClause
 }
 
 module.exports = FilterBuilder

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -1,5 +1,5 @@
 var append = require('./append')
 
-module.exports = function (search, filters) {
-  append(search, search.filter, filters)
+module.exports = function (queryClause, filters) {
+  append(queryClause, queryClause.filter, filters)
 }

--- a/lib/filtered-query.js
+++ b/lib/filtered-query.js
@@ -1,5 +1,5 @@
 var append = require('./append')
 
-module.exports = function (search, filters) {
-  append(search.query.filtered, search.query.filtered.filter, filters)
+module.exports = function (queryClause, filters) {
+  append(queryClause.query.filtered, queryClause.query.filtered.filter, filters)
 }

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -2,18 +2,18 @@ var filterStrategy = require('./filter')
 var filteredQueryStrategy = require('./filtered-query')
 var queryStrategy = require('./query')
 
-function isFilteredQuery (search) {
-  return !!(search.query && search.query.filtered)
+function isFilteredQuery (queryClause) {
+  return !!(queryClause.query && queryClause.query.filtered)
 }
 
-function isQuery (search) {
-  return !!search.query
+function isQuery (queryClause) {
+  return !!queryClause.query
 }
 
-module.exports = function (search) {
-  if (isFilteredQuery(search)) {
+module.exports = function (queryClause) {
+  if (isFilteredQuery(queryClause)) {
     return filteredQueryStrategy
-  } else if (isQuery(search)) {
+  } else if (isQuery(queryClause)) {
     return queryStrategy
   } else {
     return filterStrategy

--- a/test/index.js
+++ b/test/index.js
@@ -5,138 +5,138 @@ var should = require('should')
 
 describe('filter append', function () {
   it('should convert a query to a filtered query', function () {
-    var search = require('./scenarios/query.json').search
+    var queryClause = require('./scenarios/query.json').queryClause
     var filter = require('./scenarios/query.json').filter
     var output = require('./scenarios/query.json').output
 
-    var builder = new FilterBuilder(search)
+    var builder = new FilterBuilder(queryClause)
 
     builder.append(filter)
 
-    should(builder.toSearch()).deepEqual(output)
+    should(builder.toQueryClause()).deepEqual(output)
   })
 
   it('should convert a bool must filter with a single object to an array of filters', function () {
-    var search = require('./scenarios/bool-must-single-object.json').search
+    var queryClause = require('./scenarios/bool-must-single-object.json').queryClause
     var filter = require('./scenarios/bool-must-single-object.json').filter
     var output = require('./scenarios/bool-must-single-object.json').output
 
-    var builder = new FilterBuilder(search)
+    var builder = new FilterBuilder(queryClause)
 
     builder.append(filter)
 
-    should(builder.toSearch()).deepEqual(output)
+    should(builder.toQueryClause()).deepEqual(output)
   })
 
   it('should convert a filtered query\'s bool must filter with a single object to an array of filters', function () {
-    var search = require('./scenarios/filtered-query-bool-must-single-object.json').search
+    var queryClause = require('./scenarios/filtered-query-bool-must-single-object.json').queryClause
     var filter = require('./scenarios/filtered-query-bool-must-single-object.json').filter
     var output = require('./scenarios/filtered-query-bool-must-single-object.json').output
 
-    var builder = new FilterBuilder(search)
+    var builder = new FilterBuilder(queryClause)
 
     builder.append(filter)
 
-    should(builder.toSearch()).deepEqual(output)
+    should(builder.toQueryClause()).deepEqual(output)
   })
 
   it('should append directly to a bool must filter when it is an array of filters', function () {
-    var search = require('./scenarios/bool-must-array.json').search
+    var queryClause = require('./scenarios/bool-must-array.json').queryClause
     var filter = require('./scenarios/bool-must-array.json').filter
     var output = require('./scenarios/bool-must-array.json').output
 
-    var builder = new FilterBuilder(search)
+    var builder = new FilterBuilder(queryClause)
 
     builder.append(filter)
 
-    should(builder.toSearch()).deepEqual(output)
+    should(builder.toQueryClause()).deepEqual(output)
   })
 
   it('should append directly to a filtered query\'s bool must filter when it is an array of filters', function () {
-    var search = require('./scenarios/filtered-query-bool-must-array.json').search
+    var queryClause = require('./scenarios/filtered-query-bool-must-array.json').queryClause
     var filter = require('./scenarios/filtered-query-bool-must-array.json').filter
     var output = require('./scenarios/filtered-query-bool-must-array.json').output
 
-    var builder = new FilterBuilder(search)
+    var builder = new FilterBuilder(queryClause)
 
     builder.append(filter)
 
-    should(builder.toSearch()).deepEqual(output)
+    should(builder.toQueryClause()).deepEqual(output)
   })
 
   it('should convert a bool should filter to a must filter', function () {
-    var search = require('./scenarios/bool-should.json').search
+    var queryClause = require('./scenarios/bool-should.json').queryClause
     var filter = require('./scenarios/bool-should.json').filter
     var output = require('./scenarios/bool-should.json').output
 
-    var builder = new FilterBuilder(search)
+    var builder = new FilterBuilder(queryClause)
 
     builder.append(filter)
 
-    should(builder.toSearch()).deepEqual(output)
+    should(builder.toQueryClause()).deepEqual(output)
   })
 
   it('should convert a filtered querie\'s bool should filter to a must filter', function () {
-    var search = require('./scenarios/filtered-query-bool-should.json').search
+    var queryClause = require('./scenarios/filtered-query-bool-should.json').queryClause
     var filter = require('./scenarios/filtered-query-bool-should.json').filter
     var output = require('./scenarios/filtered-query-bool-should.json').output
 
-    var builder = new FilterBuilder(search)
+    var builder = new FilterBuilder(queryClause)
 
     builder.append(filter)
 
-    should(builder.toSearch()).deepEqual(output)
+    should(builder.toQueryClause()).deepEqual(output)
   })
 
   it('should convert a simple filter to a must filter', function () {
-    var search = require('./scenarios/simple-filter.json').search
+    var queryClause = require('./scenarios/simple-filter.json').queryClause
     var filter = require('./scenarios/simple-filter.json').filter
     var output = require('./scenarios/simple-filter.json').output
 
-    var builder = new FilterBuilder(search)
+    var builder = new FilterBuilder(queryClause)
 
     builder.append(filter)
 
-    should(builder.toSearch()).deepEqual(output)
+    should(builder.toQueryClause()).deepEqual(output)
   })
 
   it('should convert a filtered query\'s simple filter to a must filter', function () {
-    var search = require('./scenarios/filtered-query-simple-filter.json').search
+    var queryClause = require('./scenarios/filtered-query-simple-filter.json').queryClause
     var filter = require('./scenarios/filtered-query-simple-filter.json').filter
     var output = require('./scenarios/filtered-query-simple-filter.json').output
 
-    var builder = new FilterBuilder(search)
+    var builder = new FilterBuilder(queryClause)
 
     builder.append(filter)
 
-    should(builder.toSearch()).deepEqual(output)
+    should(builder.toQueryClause()).deepEqual(output)
   })
 
   it('should support appending an array of filters', function () {
-    var search = require('./scenarios/simple-filter.json').search
+    var queryClause = require('./scenarios/simple-filter.json').queryClause
     var filter = require('./scenarios/simple-filter.json').filter
     var output = require('./scenarios/simple-filter.json').output
 
-    var builder = new FilterBuilder(search)
+    var builder = new FilterBuilder(queryClause)
 
     builder.append([filter])
 
-    should(builder.toSearch()).deepEqual(output)
+    should(builder.toQueryClause()).deepEqual(output)
   })
 
   it('should throw if no filters are provided', function () {
-    var search = {
+    var queryClause = {
       filter: {}
     }
 
-    var builder = new FilterBuilder(search)
+    var builder = new FilterBuilder(queryClause)
     var append = function () { builder.append() }
 
     should(append).throw()
   })
 
   it('should throw if an invalid bool filter is provided', function () {
-    var search = {
+    var queryClause = {
       filter: {
         bool: {
           fredoSanta: 'Chi-Raq'
@@ -144,13 +144,13 @@ describe('filter append', function () {
       }
     }
 
-    var builder = new FilterBuilder(search)
+    var builder = new FilterBuilder(queryClause)
     var append = function () { builder.append({}) }
 
     should(append).throw()
   })
 
-  it('should throw if search is not provided', function () {
+  it('should throw if.queryClause is not provided', function () {
     var builder = function () { return new FilterBuilder(undefined) }
 
     should(builder).throw()
@@ -163,7 +163,7 @@ describe('filter append', function () {
   })
 
   it('should throw if a filtered query does not contain a filter', function () {
-    var search = {
+    var queryClause = {
       query: {
         filtered: {
           query: {}
@@ -171,13 +171,13 @@ describe('filter append', function () {
       }
     }
 
-    var builder = function () { return new FilterBuilder(search) }
+    var builder = function () { return new FilterBuilder(queryClause) }
 
     should(builder).throw()
   })
 
   it('should throw if a filtered query does not contain a query', function () {
-    var search = {
+    var queryClause = {
       query: {
         filtered: {
           filter: {}
@@ -185,20 +185,20 @@ describe('filter append', function () {
       }
     }
 
-    var builder = function () { return new FilterBuilder(search) }
+    var builder = function () { return new FilterBuilder(queryClause) }
 
     should(builder).throw()
   })
 
   it('should support chaining', function () {
-    var search = require('./scenarios/query-chaining.json').search
+    var queryClause = require('./scenarios/query-chaining.json').queryClause
     var filter = require('./scenarios/query-chaining.json').filter
     var output = require('./scenarios/query-chaining.json').output
 
-    var builder = new FilterBuilder(search)
+    var builder = new FilterBuilder(queryClause)
 
     builder.append(filter).append(filter)
 
-    should(builder.toSearch()).deepEqual(output)
+    should(builder.toQueryClause()).deepEqual(output)
   })
 })

--- a/test/scenarios/bool-must-array.json
+++ b/test/scenarios/bool-must-array.json
@@ -1,5 +1,5 @@
 {
-  "search" : {
+  "queryClause" : {
     "filter": {
       "bool": {
         "must": [

--- a/test/scenarios/bool-must-single-object.json
+++ b/test/scenarios/bool-must-single-object.json
@@ -1,5 +1,5 @@
 {
-  "search" : {
+  "queryClause" : {
     "filter": {
       "bool": {
         "must": {

--- a/test/scenarios/bool-should.json
+++ b/test/scenarios/bool-should.json
@@ -1,5 +1,5 @@
 {
-  "search" : {
+  "queryClause" : {
     "filter": {
       "bool": {
         "should": [

--- a/test/scenarios/filtered-query-bool-must-array.json
+++ b/test/scenarios/filtered-query-bool-must-array.json
@@ -1,6 +1,5 @@
 {
-  "search" : {
-    "fields": ["one"],
+  "queryClause" : {
     "query": {
       "filtered": {
         "query": {
@@ -45,7 +44,6 @@
     }
   },
   "output": {
-    "fields": ["one"],
     "query": {
       "filtered": {
         "query": {

--- a/test/scenarios/filtered-query-bool-must-single-object.json
+++ b/test/scenarios/filtered-query-bool-must-single-object.json
@@ -1,6 +1,5 @@
 {
-  "search" : {
-    "fields": ["one"],
+  "queryClause" : {
     "query": {
       "filtered": {
         "query": {
@@ -32,7 +31,6 @@
     }
   },
   "output": {
-    "fields": ["one"],
     "query": {
       "filtered": {
         "query": {

--- a/test/scenarios/filtered-query-bool-should.json
+++ b/test/scenarios/filtered-query-bool-should.json
@@ -1,6 +1,5 @@
 {
-  "search" : {
-    "fields": ["one"],
+  "queryClause" : {
     "query": {
       "filtered": {
         "query": {
@@ -47,7 +46,6 @@
     }
   },
   "output": {
-    "fields": ["one"],
     "query": {
       "filtered": {
         "query": {

--- a/test/scenarios/filtered-query-simple-filter.json
+++ b/test/scenarios/filtered-query-simple-filter.json
@@ -1,6 +1,5 @@
 {
-  "search" : {
-    "fields": ["one"],
+  "queryClause" : {
     "query": {
       "filtered": {
         "query": {
@@ -28,7 +27,6 @@
     }
   },
   "output": {
-    "fields": ["one"],
     "query": {
       "filtered": {
         "query": {

--- a/test/scenarios/query-chaining.json
+++ b/test/scenarios/query-chaining.json
@@ -1,5 +1,5 @@
 {
-  "search" : {
+  "queryClause" : {
     "query": {
       "query_string": {
         "query": "*I spy an @kyspy \\? \\* &*",

--- a/test/scenarios/query.json
+++ b/test/scenarios/query.json
@@ -1,5 +1,5 @@
 {
-  "search" : {
+  "queryClause" : {
     "query": {
       "query_string": {
         "query": "*I spy an @kyspy \\? \\* &*",

--- a/test/scenarios/simple-filter.json
+++ b/test/scenarios/simple-filter.json
@@ -1,5 +1,5 @@
 {
-  "search" : {
+  "queryClause" : {
     "filter": {
       "term": {
         "name": "Antwan Atkins"


### PR DESCRIPTION
the terminology was bad. it is not a search, but instead, a component of
a search. search related information like sorting and paging are not
included as apart of our input. it's at a higher level. this library
only acts on the query dsl portion of the actual search itself. this is
very misleading and would be sure to confuse consumers.

this will be the birth of `v2.0.0` as this is obviously a breaking change.